### PR TITLE
Add a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Django==1.4.5
+djangopypi2==0.5.8
+docutils==0.10
+gunicorn==0.17.2
+pkginfo==1.0b2
+wsgiref==0.1.2


### PR DESCRIPTION
I'd suggest to add at least a requirements.txt since djangopypi2 doesn't work with an up-to-date Django (which is 1.5.x as of today), but requires 1.4.5 (found by experiment). This will help users in dependency hell. 
