### PR TITLE
Allow access from any host in production mode

### DIFF
--- a/djangopypi2/website/settings.py
+++ b/djangopypi2/website/settings.py
@@ -36,6 +36,8 @@ ALLOW_VERSION_OVERWRITE = USER_SETTINGS['ALLOW_VERSION_OVERWRITE']
 
 MANAGERS = ADMINS
 
+ALLOWED_HOSTS = ['*']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This may not be the correct solution, but the issue remains; the app won't run in production mode without a change like this.
