### PR TITLE
User details page shows wrong information

### DIFF
--- a/djangopypi2/apps/pypi_users/templates/pypi_users/user_profile.html
+++ b/djangopypi2/apps/pypi_users/templates/pypi_users/user_profile.html
@@ -1,24 +1,24 @@
 {% extends 'pypi_users/base.html' %}
 
-{% block title %}{{ user.username }}{% endblock%}
+{% block title %}{{ user_.username }}{% endblock%}
 
 {% block content %}
 <div class="hero-unit">
-  <h1>
-    {{ user }}
-    <small>{{ user.email }}</small>
+  <h2>
+    {{ user_ }}
+    <small>{{ user_.email }}</small>
     <p>
-      Joined {{ user.date_joined }}<br/>
-      Last logged-in {{ user.last_login|timesince }} ago
+      Joined: {{ user_.date_joined }}<br/>
+      Last logged-in: {{ user_.last_login|timesince }} ago
     </p>
-  </h1>
+  </h2>
 </div>
 
 <div class="row">
   <div class="span6">
     <h2>Maintained packages</h2>
     <ul>
-      {% for package in user.packages_maintained.all %}
+      {% for package in user_.packages_maintained.all %}
       <li>
         <a href="{{ package.get_absolute_url }}">{{ package }}</a>
         <small>{{ package.summary }}</small>
@@ -29,7 +29,7 @@
   <div class="span6">
     <h2>Owned packages</h2>
     <ul>
-      {% for package in user.packages_owned.all %}
+      {% for package in user_.packages_owned.all %}
       <li>
         <a href="{{ package.get_absolute_url }}">{{ package }}</a>
         <small>{{ package.summary }}</small>

--- a/djangopypi2/apps/pypi_users/views.py
+++ b/djangopypi2/apps/pypi_users/views.py
@@ -13,7 +13,8 @@ class SingleUserMixin(SingleObjectMixin):
     model = User
     slug_field = 'username'
     slug_url_kwarg = 'username'
-    context_object_name = 'user'
+    # avoid clash with 'user' from django.contrib.auth.context_processors.auth
+    context_object_name = 'user_'
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
The page shows details of logged-in user instead of details of chosen user.
This is caused by using variable 'user' as template object name.
The variable 'user' is already used by django auth by default.
