### PR TITLE
List more information in release detail page

### DIFF
--- a/djangopypi2/apps/pypi_packages/models.py
+++ b/djangopypi2/apps/pypi_packages/models.py
@@ -186,6 +186,18 @@ class Release(models.Model):
         return self.package_info.get('summary', u'')
 
     @property
+    def author(self):
+        return self.package_info.get('author', u'')
+
+    @property
+    def home_page(self):
+        return self.package_info.get('home_page', u'')
+
+    @property
+    def license(self):
+        return self.package_info.get('license', u'')
+
+    @property
     def description(self):
         return self.package_info.get('description', u'')
 
@@ -196,7 +208,11 @@ class Release(models.Model):
     @property
     def keywords(self):
         # return keywords as set
-        return set(self.package_info.getlist('keywords')[0].split())
+        keywords = self.package_info.getlist('keywords')
+        if keywords:
+            return set(self.package_info.getlist('keywords')[0].split())
+        else:
+            return set()
 
     @models.permalink
     def get_absolute_url(self):

--- a/djangopypi2/apps/pypi_packages/templates/pypi_packages/release_detail.html
+++ b/djangopypi2/apps/pypi_packages/templates/pypi_packages/release_detail.html
@@ -50,22 +50,12 @@
 </div>
 {% endifnotequal %}
 
-<div class="row">
-  <span class="span8">
-    <div class="well well-small">
-      {% if release.description %}
-      {{ release.description|saferst }}
-      {% else %}
-      <i>This package has no description</i>
-      {% endif %}
-    </div>
-  </span>
-
-  <span class="span4">
-    {% for classifier in release.classifiers %}
-    <span class="label label-success">{{ classifier }}</span><br>
-    {% endfor %}
-  </span>
+<div class="well well-small">
+    {% if release.description %}
+    {{ release.description|saferst }}
+    {% else %}
+    <i>This package has no description</i>
+    {% endif %}
 </div>
 
 <div class="row">
@@ -110,4 +100,21 @@
     {% endif %}
   </span>
 </div>
+
+<h2>Other Information</h2>
+<ul class="unstyled">
+    <li><strong>Author:</strong> {{ release.author }}</li>
+    <li><strong>Home page:</strong> <a href="{{ release.home_page }}"> {{ release.home_page }} </a></li>
+    <li><strong>Keywords:</strong> {{ release.keywords|join:" " }}</li>
+    <li><strong>License:</strong> {{ release.license }}</li>
+    <li><strong>Classifiers:</strong>
+        <ul>
+            {% for classifier in release.classifiers %}
+            <span class="label label-success">{{ classifier }}</span><br>
+            {% endfor %}
+        </ul>
+    </li>
+    <li><strong>Package owners:</strong> {{ release.package.owners.all|join:", " }}</li>
+</ul>
+
 {% endblock %}


### PR DESCRIPTION
Currently, the release detail page doesn't show author, home page, keywords, license, classifiers, package owners.
This patch will add those info into the release detail page.
