### PR TITLE
Fixed regex for user profile page.

### DIFF
--- a/djangopypi2/apps/pypi_users/urls.py
+++ b/djangopypi2/apps/pypi_users/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 urlpatterns = patterns('',
     url(r'^users/$', views.Index.as_view(), name='djangopypi2-users'),
-    url(r'^users/(?P<username>[\w-]+)/$', views.UserDetails.as_view(), name='djangopypi2-user-profile'),
+    url(r'^users/(?P<username>[\w_.-]+)/$', views.UserDetails.as_view(), name='djangopypi2-user-profile'),
 )


### PR DESCRIPTION
Sometimes users have a "." or an undersocre in their username. Now the url will match and display the user's profile page instead of saying the page doesn't exist.